### PR TITLE
Update .gitignore and Google Sheets date format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,10 @@ token.json
 
 # uv
 .uv_cache/
+uv.lock
 
 # MCP
 .mcp.json
+
+# Serena cache
+.serena/

--- a/src/google_sheets.py
+++ b/src/google_sheets.py
@@ -202,8 +202,8 @@ class GoogleSheetsClient:
             japan_tz = ZoneInfo("Asia/Tokyo")
             japan_time = datetime.now(japan_tz)
             
-            # 日本語時間フォーマット（例: 2024年1月15日 14:30:25）
-            formatted_time = japan_time.strftime("%Y年%m月%d日 %H:%M:%S")
+            # 日時フォーマット（例: 2025/08/22 07:30）
+            formatted_time = japan_time.strftime("%Y/%m/%d %H:%M")
             
             # データ行を準備（日本語時間と温度のみ）
             row_data = [


### PR DESCRIPTION
## Summary
- Update .gitignore to exclude Serena cache (.serena/) and uv.lock
- Change Google Sheets date format from Japanese style to YYYY/MM/DD HH:MM format

## Changes
- Added `.serena/` and `uv.lock` to .gitignore
- Modified `GoogleSheetsClient.append_temperature_data()` to use simpler date format
- Removed seconds from timestamp for cleaner display

🤖 Generated with [Claude Code](https://claude.ai/code)